### PR TITLE
Solutions to issues related to performance on B200

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -19,7 +19,7 @@ from pytorch_lightning.strategies import DDPStrategy
 from pytorch_lightning.utilities import rank_zero_only
 
 from boltz.data.module.training import BoltzTrainingDataModule, DataConfig
-torch.set_float32_matmul_precision('high')
+torch.set_float32_matmul_precision('high') # or 'medium'
 
 @dataclass
 class TrainConfig:

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -19,7 +19,7 @@ from pytorch_lightning.strategies import DDPStrategy
 from pytorch_lightning.utilities import rank_zero_only
 
 from boltz.data.module.training import BoltzTrainingDataModule, DataConfig
-
+torch.set_float32_matmul_precision('high')
 
 @dataclass
 class TrainConfig:

--- a/src/boltz/model/model.py
+++ b/src/boltz/model/model.py
@@ -593,13 +593,13 @@ class Boltz1(LightningModule):
         # Only compute over parameters that are being trained
         parameters = filter(lambda p: p.requires_grad, module.parameters())
         parameters = filter(lambda p: p.grad is not None, parameters)
-        norm = torch.tensor([p.grad.norm(p=2) ** 2 for p in parameters]).sum().sqrt()
+        norm = torch.tensor([p.grad.detach().norm(p=2) ** 2 for p in parameters]).sum().sqrt()
         return norm
 
     def parameter_norm(self, module) -> float:
         # Only compute over parameters that are being trained
         parameters = filter(lambda p: p.requires_grad, module.parameters())
-        norm = torch.tensor([p.norm(p=2) ** 2 for p in parameters]).sum().sqrt()
+        norm = torch.tensor([p.detach().norm(p=2) ** 2 for p in parameters]).sum().sqrt()
         return norm
 
     def validation_step(self, batch: dict[str, Tensor], batch_idx: int):


### PR DESCRIPTION
- .detach() the tensor before performing the norm calculation (model.py)
- added torch.set_float32_matmul_precision('high') # or 'medium', that will speed up the matrix multiplications